### PR TITLE
Make ykcbf into a JIT test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bf_base
 bf_base.o
+bf_replay_jit

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,21 @@
 all:
 
+bf_replay_jit: bf_replay_jit.c
+	@if [ "${YK_DIR}" = "" ]; then \
+		echo "Please set YK_DIR in the environment"; \
+		exit 1; \
+		fi
+	clang ${CFLAGS} ${LDFLAGS} \
+		-L${YK_DIR}/target/debug/deps \
+		-Wl,-rpath=${YK_DIR}/target/debug/deps \
+		-lykcapi \
+		-I${YK_DIR}/ykcapi \
+		-fuse-ld=lld \
+		-flto \
+		-Wl,--mllvm=--embed-bitcode-final \
+		-Wl,--lto-basic-block-sections=labels \
+		-o $@ bf_replay_jit.c
+
 bf_base: bf_base.o
 	clang ${LDFLAGS} -o bf_base bf_base.o
 
@@ -19,4 +35,4 @@ bf_simple2_yk.o: bf_simple2_yk.c
 	clang -Wall -O3 ${CFLAGS} -c bf_simple2_yk.c
 
 clean:
-	rm -f bf_base bf_base.o
+	rm -f bf_base bf_base.o bf_replay_jit

--- a/bf_replay_jit.c
+++ b/bf_replay_jit.c
@@ -1,0 +1,120 @@
+// This is bf_base.c modified to replay the program via the JIT.
+
+#include <err.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <yk.h>
+#include <yk_testing.h>
+
+#define CELLS_LEN 30000
+
+void interp(char *prog, char *prog_end, char *cells, char *cells_end) {
+    char *instr = prog;
+    char *cell = cells;
+    while (instr < prog_end) {
+        switch (*instr) {
+            case '>': {
+                if (cell++ == cells_end)
+                    errx(1, "out of memory");
+                break;
+            }
+            case '<': {
+                if (cell > cells)
+                    cell--;
+                break;
+            }
+            case '+': {
+                (*cell)++;
+                break;
+            }
+            case '-': {
+                (*cell)--;
+                break;
+            }
+            case '.': {
+                if (putchar(*cell) == EOF)
+                    err(1, "(stdout)");
+                break;
+            }
+            case ',': {
+                if (read(STDIN_FILENO, cell, 1) == -1)
+                    err(1, "(stdin)");
+                break;
+            }
+            case '[': {
+                if (*cell == 0) {
+                    int count = 0;
+                    while (true) {
+                        instr++;
+                        if (*instr == ']') {
+                            if (count == 0)
+                                break;
+                            count--;
+                        } else if (*instr == '[')
+                            count++;
+                    }
+                }
+                break;
+            }
+            case ']': {
+                if (*cell != 0) {
+                    int count = 0;
+                    while (true) {
+                        instr--;
+                        if (*instr == '[') {
+                            if (count == 0)
+                                break;
+                            count--;
+                        } else if (*instr == ']')
+                            count++;
+                    }
+                }
+                break;
+            }
+            default: break;
+        }
+        instr++;
+    }
+}
+
+// Traces an entire execution of the program and then runs is a second time
+// using JITted code. Expect all output twice in sequence.
+void jit(char *prog, char *prog_end) {
+    // First run collects a trace.
+    char *cells = calloc(1, CELLS_LEN);
+    if (cells == NULL)
+        err(1, "out of memory");
+    char *cells_end = cells + CELLS_LEN;
+
+    void *tt = __yktrace_start_tracing(HW_TRACING, &prog, &prog_end, &cells, &cells_end);
+    interp(prog, prog_end, cells, cells_end);
+    void *tr = __yktrace_stop_tracing(tt);
+
+    // Compile and run trace.
+    void *ptr = __yktrace_irtrace_compile(tr);
+    __yktrace_drop_irtrace(tr);
+
+    memset(cells, '\0', CELLS_LEN);
+    void (*func)(void *, void*, void *, void *) = (void (*)(void *, void *, void *, void *))ptr;
+    func(&prog, &prog_end, &cells, &cells_end);
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2)
+        errx(1, "<filename>");
+
+    int fd = open(argv[1], O_RDONLY);
+    struct stat sb;
+    if (fstat(fd, &sb) != 0)
+        err(1, "%s", argv[1]);
+    char *prog = malloc(sb.st_size);
+    if (read(fd, prog, sb.st_size) != sb.st_size)
+        err(1, "%s", argv[1]);
+
+    jit(prog, prog + sb.st_size);
+}


### PR DESCRIPTION
This is a draft for discussion.

This change adds a new variant `bf_replay_jit`. This variant is based on `bf_base.c`. It traces the whole execution of the BF program and replays it using compiled JIT code.

The existing `lang_tester` suite is problematic because:
 - The existing expected outcomes cannot be re-used. We could fix this by doing as we did in `yk` and having different test outcome files, but I think @ltratt is working on a better solution for lang_tester?
 - Not many of the test files work with the JIT yet:
   - `hello.bf` -- works fine, but only at `-O0`, otherwise hits a mapper bug.
   - `bench.bf` -- quite a long test and takes a very long time to make a trace, eventually seg-faulting.
   - `hanoi.bf` -- overflows the PT buffer. This is understandable, as the test takes 30 seconds or so, and we'd never want to trace for that long.
   - `interp.bf` --  takes a really long time to run, even without the JIT. Will probably overflow the PT buffer too.
   - `numwarp.bf` -- ditto.

I don't want to fix this all in one go, and it's questionable whether fixing some of this (long runs) even makes sense. ~~So shall we just get `yk` to run `hello.bf` outside of `lang_tester` for now?~~ I'm tempted to say: let's get all the opt levels working for `hello.bf` and copy `bf_replay_jit.c` into the `yk` repo's lang tests. We can hardcode the input program.

Really we need a control point to test realistically.

Here's a diff between `bf_base.c` and `bf_replay_jit.c`:
```diff
--- bf_base.c	2021-06-23 10:57:10.126590303 +0100
+++ bf_replay_jit.c	2021-07-26 11:46:27.707516839 +0100
@@ -1,10 +1,15 @@
+// This is bf_base.c modified to replay the program via the JIT.
+
 #include <err.h>
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <yk.h>
+#include <yk_testing.h>
 
 #define CELLS_LEN 30000
 
@@ -77,6 +82,28 @@
     }
 }
 
+// Traces an entire execution of the program and then runs is a second time
+// using JITted code. Expect all output twice in sequence.
+void jit(char *prog, char *prog_end) {
+    // First run collects a trace.
+    char *cells = calloc(1, CELLS_LEN);
+    if (cells == NULL)
+        err(1, "out of memory");
+    char *cells_end = cells + CELLS_LEN;
+
+    void *tt = __yktrace_start_tracing(HW_TRACING, &prog, &prog_end, &cells, &cells_end);
+    interp(prog, prog_end, cells, cells_end);
+    void *tr = __yktrace_stop_tracing(tt);
+
+    // Compile and run trace.
+    void *ptr = __yktrace_irtrace_compile(tr);
+    __yktrace_drop_irtrace(tr);
+
+    memset(cells, '\0', CELLS_LEN);
+    void (*func)(void *, void*, void *, void *) = (void (*)(void *, void *, void *, void *))ptr;
+    func(&prog, &prog_end, &cells, &cells_end);
+}
+
 int main(int argc, char *argv[]) {
     if (argc < 2)
         errx(1, "<filename>");
@@ -89,9 +116,5 @@
     if (read(fd, prog, sb.st_size) != sb.st_size)
         err(1, "%s", argv[1]);
 
-    char *cells = calloc(1, CELLS_LEN);
-    if (cells == NULL)
-        err(1, "out of memory");
-
-    interp(prog, prog + sb.st_size, cells, cells + CELLS_LEN);
+    jit(prog, prog + sb.st_size);
 }
```